### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = vwo
 appName = com.enonic.app.vwo
 xpVersion = 8.0.0-B4
-version = 1.4.3-SNAPSHOT
+version = 2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bump `version` in `gradle.properties` from `1.4.3-SNAPSHOT` to `2.0.0-SNAPSHOT` so master targets XP 8.
- Add `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x`, so pushes on either branch are recognized as release branches by `enonic/release-tools/build-and-publish`.

The XP 7 maintenance line continues on the new `1.x` branch (cut from the post-release SNAPSHOT commit `07017a3`, where `gradle.properties` is at `1.4.3-SNAPSHOT` and `xpVersion = 7.3.0`).

## Test plan
- [ ] CI green on this PR
- [ ] After merge, `./gradlew clean build` from master is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)