### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x`, so pushes on `1.x` are recognized as release-branch builds by `enonic/release-tools/build-and-publish` (the action reads `releaseBranch:` from the branch's own workflow file).

This is the maintenance counterpart to the master PR that bumps to `2.0.0-SNAPSHOT`. The XP 7 line continues here with `xpVersion = 7.3.0` / `version = 1.4.3-SNAPSHOT`.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, a CI run on `1.x` classifies it as a release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)