### PR TITLE
Migrate to lib-static #818

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     include xplibs.context
     include xplibs.portal
     include libs.lib.mustache
-    include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-router:4.0.0-SNAPSHOT"
+    include libs.lib.static
+    include libs.lib.router
     include libs.jackson.databind
     include libs.httpclient
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     include xplibs.context
     include xplibs.portal
     include "com.enonic.lib:lib-mustache:2.1.1"
+    include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"
+    include "com.enonic.lib:lib-router:4.0.0-SNAPSHOT"
     include 'com.fasterxml.jackson.core:jackson-databind:2.21.3'
     include 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,12 @@
 httpclient = "4.5.14"
 jackson-databind = "2.21.3"
 mustache = "2.1.1"
+router = "4.0.0-SNAPSHOT"
+static = "3.0.0-SNAPSHOT"
 
 [libraries]
 httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpclient" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson-databind" }
 lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
+lib-router = { module = "com.enonic.lib:lib-router", version.ref = "router" }
+lib-static = { module = "com.enonic.lib:lib-static", version.ref = "static" }

--- a/src/main/resources/admin/extensions/vwo-campaign/vwo-campaign.js
+++ b/src/main/resources/admin/extensions/vwo-campaign/vwo-campaign.js
@@ -62,10 +62,10 @@ router.get(STATIC_BASE_PATH + '/{path:.*}', function (req) {
     return staticLib.requestHandler(req, {
         index: false,
         root: '/assets',
-        relativePath: staticLib.mappedRelativePath(STATIC_BASE_PATH)
+        relativePath: function (r) { return r.pathParams.path; }
     });
 });
 
-exports.all = function (req) {
+exports.GET = function (req) {
     return router.dispatch(req);
 };

--- a/src/main/resources/admin/extensions/vwo-campaign/vwo-campaign.js
+++ b/src/main/resources/admin/extensions/vwo-campaign/vwo-campaign.js
@@ -1,8 +1,12 @@
 const portalLib = require('/lib/xp/portal');
 const mustacheLib = require('/lib/mustache');
+const staticLib = require('/lib/enonic/static');
 const helper = require('/helper/helper');
+const router = require('/lib/router')();
 
-function handleGet(req) {
+const STATIC_BASE_PATH = '/_static';
+
+router.get('', function (req) {
     let contentId = req.params.contentId;
 
     if (!contentId && portalLib.getContent()) {
@@ -16,13 +20,14 @@ function handleGet(req) {
         };
     }
 
+    const baseAssetUrl = req.contextPath + STATIC_BASE_PATH;
     const errorMessage = helper.validate(contentId);
 
     if (errorMessage) {
         return {
             contentType: 'text/html',
             body: mustacheLib.render(resolve('vwo-error.html'), {
-                vwoCssUrl: portalLib.assetUrl({path: 'css/bundle.css'}),
+                vwoCssUrl: baseAssetUrl + '/css/bundle.css',
                 widgetId: app.name,
                 errorMessage
             })
@@ -32,8 +37,8 @@ function handleGet(req) {
     const contentProperties = helper.getContentProperties(contentId);
 
     const params = {
-        vwoCssUrl: portalLib.assetUrl({path: 'css/bundle.css'}),
-        vwoJsUrl: portalLib.assetUrl({path: 'js/bundle.js'}),
+        vwoCssUrl: baseAssetUrl + '/css/bundle.css',
+        vwoJsUrl: baseAssetUrl + '/js/bundle.js',
         configServiceUrl: portalLib.serviceUrl({
             service: 'config',
             params: {
@@ -51,6 +56,16 @@ function handleGet(req) {
         contentType: 'text/html',
         body: mustacheLib.render(view, params)
     };
-}
+});
 
-exports.get = handleGet;
+router.get(STATIC_BASE_PATH + '/{path:.*}', function (req) {
+    return staticLib.requestHandler(req, {
+        index: false,
+        root: '/assets',
+        relativePath: staticLib.mappedRelativePath(STATIC_BASE_PATH)
+    });
+});
+
+exports.all = function (req) {
+    return router.dispatch(req);
+};


### PR DESCRIPTION
Closes #818

`portal.assetUrl` is marked `@deprecated` in lib-portal ("Use libAsset or libStatic instead. This function will be removed in future versions."). The only call sites in this app live inside an admin extension (`contentstudio.contextpanel`), where lib-asset is explicitly not suitable per its [docs](https://developer.enonic.com/docs/lib-asset/stable) — so this PR migrates to **lib-static**.

## Changes

- **`build.gradle`** — `include` `com.enonic.lib:lib-static:3.0.0-SNAPSHOT` and `com.enonic.lib:lib-router:4.0.0-SNAPSHOT` (lib-static is a Universal API and needs a route to mount it under the extension).
- **`src/main/resources/admin/extensions/vwo-campaign/vwo-campaign.js`** — switch the entry point from `exports.get` to `exports.all` backed by `lib-router`; the main view is served at `''`, and `/_static/{path:.*}` is delegated to `staticLib.requestHandler(...)` with `root: '/assets'`. Asset URLs in the rendered templates now use `req.contextPath + '/_static/css/bundle.css'` (and `/js/bundle.js`) instead of `portal.assetUrl(...)`.

No descriptor `apis:` change is needed — lib-static is mounted in-extension via lib-router, not declared on the extension YAML.

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean.
- [x] App jar bundles `lib/enonic/static/**` and `lib/router.js`; bundle reaches `Started application com.enonic.app.vwo` in the XP 8.0.0-B4 log.
- [x] With the extension temporarily exposed under `admin.dashboard` (reverted before commit) and the main admin tool as host, the generated asset paths return assets:
  - `GET …/_static/css/bundle.css` → 200, `text/css`, 16662 bytes.
  - `GET …/_static/js/bundle.js` → 200, `application/javascript`, 312532 bytes.
  - `GET …/_static/nonexistent.css` → 404 from the lib-static handler.
- [ ] Real-world verification: load a Content Studio context panel showing the VWO widget on a site with valid `vwo.accountId` / `vwo.token` and confirm CSS + JS load (cannot be exercised here without Content Studio installed; covered by the smoke test above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)