### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,9 @@ dependencies {
     include xplibs.content
     include xplibs.context
     include xplibs.portal
-    include "com.enonic.lib:lib-mustache:2.1.1"
-    include 'com.fasterxml.jackson.core:jackson-databind:2.21.3'
-    include 'org.apache.httpcomponents:httpclient:4.5.14'
+    include libs.lib.mustache
+    include libs.jackson.databind
+    include libs.httpclient
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+httpclient = "4.5.14"
+jackson-databind = "2.21.3"
+mustache = "2.1.1"
+
+[libraries]
+httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpclient" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson-databind" }
+lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }


### PR DESCRIPTION
## Summary

Move pinned dependency versions out of `build.gradle` into a new `gradle/libs.versions.toml` catalog. Pin-for-pin migration — no version bumps. `xpVersion` stays in `gradle.properties` as a regular Gradle property, and `xplibs.*` accessors are unchanged.

## Conventions

- Alphabetical sort of `[versions]` and `[libraries]`.
- Hyphen-separated, lowercase keys.
- For Enonic libraries, the version key is short and the library key carries the `lib-` prefix (matches the dominant style in neighbouring catalogs such as `app-features` and `app-livetrace`).

## Catalog

```toml
[versions]
httpclient = "4.5.14"
jackson-databind = "2.21.3"
mustache = "2.1.1"

[libraries]
httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpclient" }
jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson-databind" }
lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
```

## Verification

- `./gradlew build --refresh-dependencies` — green.
- `./gradlew :dependencies --configuration runtimeClasspath` — output identical to pre-migration apart from the trailing `BUILD SUCCESSFUL in …` line.

## Test plan

- [x] Build is green locally
- [x] Resolved `runtimeClasspath` matches pre-migration tree
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)